### PR TITLE
Allow to run capture_data.py without .env

### DIFF
--- a/demos/basic.py
+++ b/demos/basic.py
@@ -2,10 +2,11 @@
 import asyncio
 
 from lib.rcon import Rcon
-from lib.constants import RCON_HOST, RCON_PASSWORD, RCON_PORT
+from lib.constants import RCON_HOST, RCON_PASSWORD, RCON_PORT, validate_env
 
 
 async def main():
+    validate_env()
     client = Rcon(
         host=RCON_HOST,
         port=RCON_PORT,

--- a/demos/minimap.py
+++ b/demos/minimap.py
@@ -5,7 +5,7 @@ import threading
 import tkinter as tk
 
 from lib.rcon import Rcon
-from lib.constants import RCON_HOST, RCON_PASSWORD, RCON_PORT
+from lib.constants import RCON_HOST, RCON_PASSWORD, RCON_PORT, validate_env
 from lib.exceptions import HLLError
 
 TACMAP_PATH = Path("assets/tacmaps/tobruk.png")
@@ -101,6 +101,7 @@ class RconThread(threading.Thread):
                     )
 
 def main():
+    validate_env()
     root = tk.Tk()
     tacmap = Minimap(root)
     tacmap.pack(fill="both", expand=True)

--- a/demos/protocol.py
+++ b/demos/protocol.py
@@ -1,11 +1,12 @@
 
 import asyncio
 
-from lib.constants import RCON_HOST, RCON_PASSWORD, RCON_PORT
+from lib.constants import RCON_HOST, RCON_PASSWORD, RCON_PORT, validate_env
 from lib.protocol import HLLRconV2Protocol
 
 
 async def main():
+    validate_env()
     protocol = await HLLRconV2Protocol.connect(
         host=RCON_HOST,
         port=RCON_PORT,

--- a/demos/reconnect.py
+++ b/demos/reconnect.py
@@ -3,11 +3,12 @@ from datetime import datetime
 import logging
 
 from lib.rcon import Rcon
-from lib.constants import RCON_HOST, RCON_PASSWORD, RCON_PORT
+from lib.constants import RCON_HOST, RCON_PASSWORD, RCON_PORT, validate_env
 from lib.exceptions import HLLError
 
 
 async def main():
+    validate_env()
     rcon = Rcon(
         host=RCON_HOST,
         port=RCON_PORT,

--- a/demos/stress.py
+++ b/demos/stress.py
@@ -3,10 +3,11 @@ import asyncio
 import time
 
 from lib.rcon import Rcon
-from lib.constants import RCON_HOST, RCON_PASSWORD, RCON_PORT
+from lib.constants import RCON_HOST, RCON_PASSWORD, RCON_PORT, validate_env
 
 
 async def main():
+    validate_env()
     rcon = Rcon(
         host=RCON_HOST,
         port=RCON_PORT,

--- a/demos/stress_pooled.py
+++ b/demos/stress_pooled.py
@@ -1,12 +1,12 @@
-
 import asyncio
 import time
 
+from lib.constants import RCON_HOST, RCON_PASSWORD, RCON_PORT, validate_env
 from lib.pooled_rcon import PooledRcon
-from lib.constants import RCON_HOST, RCON_PASSWORD, RCON_PORT
 
 
 async def main():
+    validate_env()
     rcon = PooledRcon(
         host=RCON_HOST,
         port=RCON_PORT,
@@ -33,6 +33,7 @@ async def main():
     ]) or "None")
     print(f"Took: {end_time - start_time:.3f} seconds")
     print()
+
 
 if __name__ == '__main__':
     asyncio.run(main())

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -11,16 +11,17 @@ RCON_HOST: Final[str] = os.getenv("RCON_HOST", "")
 RCON_PORT: Final[int] = int(os.getenv("RCON_PORT", 0))
 RCON_PASSWORD: Final[str] = os.getenv("RCON_PASSWORD", "")
 
-if not RCON_HOST:
-    raise Exception("Missing RCON_HOST environment variable")
-if not RCON_PORT:
-    raise Exception("Missing RCON_PORT environment variable")
-if not RCON_PASSWORD:
-    raise Exception("Missing RCON_PASSWORD environment variable")
-
 DO_XOR_RESPONSES: Final[bool] = False
 DO_USE_REQUEST_HEADERS: Final[bool] = False
 DO_POP_V1_XORKEY: Final[bool] = True
 
 HEADER_FORMAT = "<II"
 DO_WAIT_BETWEEN_REQUESTS: float = 0.0
+
+def validate_env():
+    if not RCON_HOST:
+        raise Exception("Missing RCON_HOST environment variable")
+    if not RCON_PORT:
+        raise Exception("Missing RCON_PORT environment variable")
+    if not RCON_PASSWORD:
+        raise Exception("Missing RCON_PASSWORD environment variable")


### PR DESCRIPTION
capture_data.py has a dict with the server configuration and hence does not need the corresponding env variables. However, the constants.py checked the existence of these env vars unconditionally. Resulting in an error message that the env vars are missing when running capture_data.py.

This commit fixes this behaviour and will only check the existence of env vars when they're actually required.